### PR TITLE
面接予約を作成する機能の実装

### DIFF
--- a/app/assets/stylesheets/interviews.scss
+++ b/app/assets/stylesheets/interviews.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Interviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class InterviewsController < ApplicationController
+  def new; end
+
+  def index; end
+
+  def edit; end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -3,7 +3,13 @@
 class InterviewsController < ApplicationController
   def new; end
 
+  def create; end
+
   def index; end
 
   def edit; end
+
+  def update; end
+
+  def destroy; end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 class InterviewsController < ApplicationController
-  def new; end
+  def new
+    @interview = current_user.interviews.build
+  end
 
-  def create; end
+  def create
+    @interview = current_user.interviews.build(interview_params)
+    if @interview.save
+      flash[:success] = '面接を予約しました'
+      redirect_to user_interviews_path(current_user)
+    else
+      flash[:danger] = '面接の予約に失敗しました'
+    end
+  end
 
   def index; end
 
@@ -12,4 +22,10 @@ class InterviewsController < ApplicationController
   def update; end
 
   def destroy; end
+
+  private
+
+  def interview_params
+    params.require(:interview).permit(:interviewer_id, :interviewee_id, :scheduled_at)
+  end
 end

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -2,4 +2,7 @@
 
 class Interview < ApplicationRecord
   belongs_to :interviewer, class_name: 'User'
+  validates :interviewer_id, presence: true
+  validates :interviewee_id, presence: true
+  validates :scheduled_at, presence: true
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Interview < ApplicationRecord
+  belongs_to :interviewer, class_name: 'User'
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Interview < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  has_many :interviews
+  has_many :interviews, foreign_key: 'interviewee_id'
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_many :interviews
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   enum gender: { female: 1, male: 2, other: 3 }
+
+  # 自分以外のユーザを面接官として返す
+  def interviewers
+    User.where.not(id: id)
+  end
 end

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#edit</h1>
+<p>Find me in app/views/interviews/edit.html.erb</p>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#index</h1>
+<p>Find me in app/views/interviews/index.html.erb</p>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#new</h1>
+<p>Find me in app/views/interviews/new.html.erb</p>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,2 +1,17 @@
-<h1>Interviews#new</h1>
-<p>Find me in app/views/interviews/new.html.erb</p>
+<h2>面接予約</h2>
+
+<%= form_with model: @interview, url: user_interviews_path(current_user), local: true do |f| %>
+  <div class="field">
+    <%= f.label '面接官' %><br />
+    <%= f.collection_select(:interviewer_id, current_user.interviewers, :id, :name) %>
+  </div>
+
+  <div class="field">
+    <%= f.label :scheduled_at %><br />
+    <%= f.datetime_select :scheduled_at, value: Time.now %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "予約" %>
+  </div>
+<% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,9 +1,10 @@
 <header>
-  <%= link_to "e-Navigator", "#", class: "logo" %>
+  <%= link_to "e-Navigator", root_path, class: "logo" %>
   <% if user_signed_in? %>
     <%= link_to "ホーム", root_path, class: "button" %>
     <%= link_to "プロフィール", edit_user_registration_path, class: "button" %>
-    <%= link_to "面接一覧", "#", class: "button" %>
+    <%= link_to "面接予約", new_user_interview_path(current_user), class: "button" %>
+    <%= link_to "面接一覧", user_interviews_path(current_user), class: "button" %>
     <%= link_to "ログアウト", logout_path, class: "button", method: :delete, data: { confirm: "ログアウトしてよろしいですか？" } %>
   <% else %>
     <%= link_to "ログイン", login_path, class: "button" %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -23,6 +23,8 @@ ja:
     confirmations:
       new:
         resend_confirmation_instructions: "アカウント確認メール再送"
+    failure:
+      already_authenticated: "既にログインしています"
     mailer:
       confirmation_instructions:
         action: "アカウント確認"
@@ -63,6 +65,9 @@ ja:
     sessions:
       new:
         sign_in: "ログイン"
+      signed_in: "ログインしました"
+      signed_out: "ログインに失敗しました"
+      already_signed_out: "ログアウトしました"
     shared:
       links:
         back: "戻る"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,7 @@ Rails.application.routes.draw do
     post 'login', to: 'devise/sessions#create'
     delete 'logout', to: 'devise/sessions#destroy'
   end
+  resources :users do
+    resources :interviews
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get 'interviews/new'
+  get 'interviews/index'
+  get 'interviews/edit'
   devise_for :users,
              controllers: {
                registrations: 'users/registrations',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'interviews/new'
-  get 'interviews/index'
-  get 'interviews/edit'
+  root 'pages#home'
   devise_for :users,
              controllers: {
                registrations: 'users/registrations',
                sessions: 'users/sessions',
                passwords: 'users/passwords'
              }
-  root 'pages#home'
-  get 'pages/index'
-  get 'pages/show'
-
   devise_scope :user do
     get 'login', to: 'devise/sessions#new'
     post 'login', to: 'devise/sessions#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,13 @@ Rails.application.routes.draw do
                sessions: 'users/sessions',
                passwords: 'users/passwords'
              }
+
   devise_scope :user do
     get 'login', to: 'devise/sessions#new'
     post 'login', to: 'devise/sessions#create'
     delete 'logout', to: 'devise/sessions#destroy'
   end
+
   resources :users do
     resources :interviews
   end

--- a/db/migrate/20200127101651_create_interviews.rb
+++ b/db/migrate/20200127101651_create_interviews.rb
@@ -2,13 +2,6 @@
 
 class CreateInterviews < ActiveRecord::Migration[6.0]
   def change
-    create_table :interviews do |t|
-      t.datetime :schedule
-      t.boolean :attendable
-      t.integer :interviewer_id
-      t.integer :interviewee_id
-
-      t.timestamps
-    end
+    create_table :interviews, &:timestamps
   end
 end

--- a/db/migrate/20200127101651_create_interviews.rb
+++ b/db/migrate/20200127101651_create_interviews.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateInterviews < ActiveRecord::Migration[6.0]
+  def change
+    create_table :interviews do |t|
+      t.datetime :schedule
+      t.boolean :attendable
+      t.integer :interviewer_id
+      t.integer :interviewee_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200130032708_add_column_to_interview.rb
+++ b/db/migrate/20200130032708_add_column_to_interview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddColumnToInterview < ActiveRecord::Migration[6.0]
+  def change
+    add_column :interviews, :interviewer_id, :integer
+    add_column :interviews, :interviewee_id, :integer
+    add_column :interviews, :scheduled_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_26_155014) do
+ActiveRecord::Schema.define(version: 2020_01_27_101651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.datetime "schedule"
+    t.boolean "attendable"
+    t.integer "interviewer_id"
+    t.integer "interviewee_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_27_101651) do
+ActiveRecord::Schema.define(version: 2020_01_30_032708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,9 @@ ActiveRecord::Schema.define(version: 2020_01_27_101651) do
   create_table "interviews", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "interviewer_id"
+    t.integer "interviewee_id"
+    t.datetime "scheduled_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,10 +16,6 @@ ActiveRecord::Schema.define(version: 2020_01_27_101651) do
   enable_extension "plpgsql"
 
   create_table "interviews", force: :cascade do |t|
-    t.datetime "schedule"
-    t.boolean "attendable"
-    t.integer "interviewer_id"
-    t.integer "interviewee_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+
+User.create!(name: 'Yuma Shiraishi',
+             email: 'shiraishi@test.com',
+             password: 'password',
+             password_confirmation: 'password')
+
+User.create!(name: 'Yosuke Obata',
+             email: 'obata@test.com',
+             password: 'password',
+             password_confirmation: 'password')
+
+User.create!(name: 'Miki Miyazato',
+             email: 'miyazato@test.com',
+             password: 'password',
+             password_confirmation: 'password')

--- a/spec/controllers/interviews_controller_spec.rb
+++ b/spec/controllers/interviews_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InterviewsController, type: :controller do
+  describe 'GET #new' do
+    it 'returns http success' do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns http success' do
+      get :edit
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/factories/interviews.rb
+++ b/spec/factories/interviews.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :interview do
+    schedule { '2020-01-27 19:16:51' }
+    attendable { false }
+    interviewer_id { 1 }
+    interviewee_id { 1 }
+  end
+end

--- a/spec/models/interview_spec.rb
+++ b/spec/models/interview_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Interview, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## やりたいこと
- ユーザが面接予約の作成をできるようにする

## やったこと
- interview モデルの new メソッド及び create メソッドの実装
- 面接登録画面の作成
- 面接官を自分以外のユーザと定義し、自分以外のユーザを返すメソッド interviewers を User のインスタンスメソッドとして実装

## 動作確認方法
### ローカル
- `$ bin/rails db:migrate` でデータベースを更新する
- `$ bin/rails s` でサーバを立てる
- http://localhost:3000/ にアクセス

### Web
- （現在ビルド中） にアクセス

### 確認してほしいこと
- 適当なユーザでログイン（下記は登録済みテスト用ユーザ）
  - email: test@test.jp
  - password: password
- 面接予約ページを表示
- 面接官が表示されるか確認
- 適当な面接官と日時を入力して面接予約できるか確認
