### PR TITLE
面接の削除機能の追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,7 @@ Style/TrailingCommaInArrayLiteral:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+# 同一行に複数のステートメントの記述OK
+Style/Semicolon:
+  AllowAsExpressionSeparator: true

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -27,8 +27,7 @@ class InterviewsController < ApplicationController
   def update; end
 
   def destroy
-    @interview = current_user.interviews.find_by(id: params[:id])
-    @interview.destroy
+    current_user.interviews.find_by(id: params[:id]).destroy
     flash[:success] = '面接予約を削除しました'
     redirect_to user_interviews_path(current_user)
   end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -26,7 +26,12 @@ class InterviewsController < ApplicationController
 
   def update; end
 
-  def destroy; end
+  def destroy
+    @interview = current_user.interviews.find_by(id: params[:id])
+    @interview.destroy
+    flash[:success] = '面接予約を削除しました'
+    redirect_to user_interviews_path(current_user)
+  end
 
   private
 

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -19,7 +19,7 @@
       <%= link_to "編集", edit_user_interview_path(current_user, interview) %></p>
     </td>
     <td>
-      <%= link_to "削除", user_interview_path(current_user, interview), method: :delete %></p>
+      <%= link_to "削除", user_interview_path(current_user, interview), data: { confirm: "本当によろしいですか？" }, method: :delete %></p>
     </td>
   </tr>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -44,8 +44,9 @@ ja:
         resend_confirmation_instructions: アカウント確認メール再送
     failure:
       already_authenticated: 既にログインしています
-      invalid: 不不正な%{authentication_keys}またはパスワードです
+      invalid: 不正な%{authentication_keys}またはパスワードです
       not_found_in_database: 不正な%{authentication_keys}またはパスワードです
+      unauthenticated: 操作を継続するためにはログインする必要があります
     mailer:
       confirmation_instructions:
         action: アカウント確認

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -49,12 +49,25 @@ RSpec.describe InterviewsController, type: :request do
         delete user_interview_path(user, interview)
         expect(response).to have_http_status '302'
       end
+
+      it 'deletes an interview' do
+        sign_in user
+        expect  do
+          delete user_interview_path(user, interview)
+        end.to change(user.interviews, :count).by(0)
+      end
     end
 
     context 'as an unauthorized' do
       it 'returns 302 response' do
         delete user_interview_path(user, interview)
         expect(response).to have_http_status '302'
+      end
+
+      it 'does not delete an interview' do
+        expect do
+          delete user_interview_path(user, interview)
+        end.to change(user.interviews, :count).by(1)
       end
     end
   end

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -42,9 +42,7 @@ RSpec.describe InterviewsController, type: :request do
       it { is_expected.to have_http_status '302' }
 
       it 'deletes an interview' do
-        expect do
-          delete user_interview_path(user, interview)
-        end.to change(user.interviews, :count).by(0)
+        expect { subject }.to change(user.interviews, :count).by(0)
       end
     end
 
@@ -52,9 +50,7 @@ RSpec.describe InterviewsController, type: :request do
       it { is_expected.to have_http_status '302' }
 
       it 'does not delete an interview' do
-        expect do
-          delete user_interview_path(user, interview)
-        end.to change(user.interviews, :count).by(1)
+        expect { subject }.to change(user.interviews, :count).by(1)
       end
     end
   end

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -9,60 +9,47 @@ RSpec.describe InterviewsController, type: :request do
   let(:params) { { interviewer: interviewer, schedule: Time.now.tomorrow, schedule_status: 'pending' } }
 
   describe 'GET #new' do
+    subject { get new_user_interview_path(user), params: { user_id: user.id }; response }
+
     context 'as an authenticated user' do
-      it 'returns 200 response' do
-        sign_in user
-        get new_user_interview_path(user), params: { user_id: user.id }
-        expect(response).to have_http_status '200'
-      end
+      before { sign_in user }
+      it { is_expected.to have_http_status '200' }
     end
 
     context 'as an unauthorized' do
-      it 'returns 302 response' do
-        get new_user_interview_path(user), params: { user_id: user.id }
-        expect(response).to have_http_status '302'
-      end
+      it { is_expected.to have_http_status '302' }
     end
   end
 
   describe 'GET #index' do
+    subject { get user_interviews_path(user); response }
+
     context 'as an authenticated user' do
-      it 'returns 200 response' do
-        sign_in user
-        get user_interviews_path(user)
-        expect(response).to have_http_status '200'
-      end
+      before { sign_in user }
+      it { is_expected.to have_http_status '200' }
     end
 
     context 'as an unauthorized' do
-      it 'returns 302 response' do
-        get user_interviews_path(user)
-        expect(response).to have_http_status '302'
-      end
+      it { is_expected.to have_http_status '302' }
     end
   end
 
   describe 'DELETE #destroy' do
+    subject { delete user_interview_path(user, interview); response }
+
     context 'as an authenticated user' do
-      it 'returns 200 response' do
-        sign_in user
-        delete user_interview_path(user, interview)
-        expect(response).to have_http_status '302'
-      end
+      before { sign_in user }
+      it { is_expected.to have_http_status '302' }
 
       it 'deletes an interview' do
-        sign_in user
-        expect  do
+        expect do
           delete user_interview_path(user, interview)
         end.to change(user.interviews, :count).by(0)
       end
     end
 
     context 'as an unauthorized' do
-      it 'returns 302 response' do
-        delete user_interview_path(user, interview)
-        expect(response).to have_http_status '302'
-      end
+      it { is_expected.to have_http_status '302' }
 
       it 'does not delete an interview' do
         expect do

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.describe InterviewsController, type: :request do
   let(:user) { FactoryBot.create(:user) }
+  let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+  let(:interview) { user.interviews.create(params) }
+  let(:params) { { interviewer: interviewer, schedule: Time.now.tomorrow, schedule_status: 'pending' } }
 
   describe 'GET #new' do
     context 'as an authenticated user' do
@@ -34,6 +37,23 @@ RSpec.describe InterviewsController, type: :request do
     context 'as an unauthorized' do
       it 'returns 302 response' do
         get user_interviews_path(user)
+        expect(response).to have_http_status '302'
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'as an authenticated user' do
+      it 'returns 200 response' do
+        sign_in user
+        delete user_interview_path(user, interview)
+        expect(response).to have_http_status '302'
+      end
+    end
+
+    context 'as an unauthorized' do
+      it 'returns 302 response' do
+        delete user_interview_path(user, interview)
         expect(response).to have_http_status '302'
       end
     end


### PR DESCRIPTION
## やりたいこと
- ユーザが面接を削除できるようにする

## やったこと
- interview の削除機能の実装
- リクエストスペックの追加

## 動作確認方法
### ローカル
- `$ bin/rails db:migrate` でデータベースを更新する
- `$ bin/rails s` でサーバを立てる
- http://localhost:3000/ にアクセス

### Web
- https://interview-sc-dev-interv-myr2g8.herokuapp.com/

### 確認してほしいこと
- 適当なユーザでログイン（下記は登録済みテスト用ユーザ）
  - email: shiraishi@test.jp
  - password: password
- 面接一覧ページの削除リンクから面接予約の削除ができるかどうか
- request spec がいい感じにかけているかどうか（特に let の使い方）