### PR TITLE
Dev/interview edit

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -28,7 +28,7 @@ class InterviewsController < ApplicationController
 
   def update
     @interview = Interview.find(params[:id])
-    if @interview.update_attributes(interview_params)
+    if @interview.update(interview_params)
       flash[:success] = '面接を更新しました'
       redirect_to user_interviews_path(current_user)
     else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -22,7 +22,9 @@ class InterviewsController < ApplicationController
     @interviews = current_user.interviews.includes(:user, :interviewer)
   end
 
-  def edit; end
+  def edit
+    @interview = current_user.interviews.find_by(id: params[:id])
+  end
 
   def update; end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -26,7 +26,16 @@ class InterviewsController < ApplicationController
     @interview = current_user.interviews.find_by(id: params[:id])
   end
 
-  def update; end
+  def update
+    @interview = Interview.find(params[:id])
+    if @interview.update_attributes(interview_params)
+      flash[:success] = '面接を更新しました'
+      redirect_to user_interviews_path(current_user)
+    else
+      flash[:danger] = '面接の更新に失敗しました。（過去の日付は選択できません）'
+      render 'edit'
+    end
+  end
 
   def destroy
     current_user.interviews.find_by(id: params[:id]).destroy

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -13,7 +13,7 @@ class InterviewsController < ApplicationController
       flash[:success] = '面接を予約しました'
       redirect_to user_interviews_path(current_user)
     else
-      flash[:danger] = '面接の予約に失敗しました。（過去の日付は選択できません）'
+      flash[:danger] = '面接の予約に失敗しました。'
       render 'new'
     end
   end
@@ -32,7 +32,7 @@ class InterviewsController < ApplicationController
       flash[:success] = '面接を更新しました'
       redirect_to user_interviews_path(current_user)
     else
-      flash[:danger] = '面接の更新に失敗しました。（過去の日付は選択できません）'
+      flash[:danger] = '面接の更新に失敗しました。'
       render 'edit'
     end
   end

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -1,0 +1,15 @@
+<%= form_with model: @interview, url: yield(:url), local: true do |f| %>
+  <div class="field">
+    <%= f.label :interviewer_id %><br />
+    <%= f.collection_select(:interviewer_id, User.interviewer, :id, :name ) %>
+  </div>
+
+  <div class="field">
+    <%= f.label :schedule %><br />
+    <%= f.datetime_select :schedule, minute_step: 15, value: yield(:time) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit yield(:submit_label) %>
+  </div>
+<% end %>

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -9,6 +9,12 @@
     <%= f.datetime_select :schedule, minute_step: 15, value: yield(:time) %>
   </div>
 
+    <% @interview.errors.full_messages.each do |message| %>
+      <div class="card error">
+        <%= message %>
+      </div>
+    <% end %>
+
   <div class="actions">
     <%= f.submit yield(:submit_label) %>
   </div>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,2 +1,17 @@
-<h1>Interviews#edit</h1>
-<p>Find me in app/views/interviews/edit.html.erb</p>
+<h2>面接予約変更</h2>
+
+<%= form_with model: @interview, url: user_interview_path(current_user, @interview), local: true do |f| %>
+  <div class="field">
+    <%= f.label :interviewer_id %><br />
+    <%= f.collection_select(:interviewer_id, User.interviewer, :id, :name, { selected: @interview.interviewer_id }) %>
+  </div>
+
+  <div class="field">
+    <%= f.label :schedule %><br />
+    <%= f.datetime_select :schedule, minute_step: 15, value: @interview.schedule %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "変更" %>
+  </div>
+<% end %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,17 +1,6 @@
+<% provide(:url, user_interview_path(current_user, @interview)) %>
+<% provide(:submit_label, '変更') %>
+<% provide(:time, @interview.schedule) %>
 <h2>面接予約変更</h2>
 
-<%= form_with model: @interview, url: user_interview_path(current_user, @interview), local: true do |f| %>
-  <div class="field">
-    <%= f.label :interviewer_id %><br />
-    <%= f.collection_select(:interviewer_id, User.interviewer, :id, :name, { selected: @interview.interviewer_id }) %>
-  </div>
-
-  <div class="field">
-    <%= f.label :schedule %><br />
-    <%= f.datetime_select :schedule, minute_step: 15, value: @interview.schedule %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "変更" %>
-  </div>
-<% end %>
+<%= render 'form' %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,17 +1,7 @@
+<% provide(:url, user_interviews_path(current_user)) %>
+<% provide(:submit_label, '予約') %>
+<% provide(:time, Time.now) %>
+
 <h2>面接予約</h2>
 
-<%= form_with model: @interview, url: user_interviews_path(current_user), local: true do |f| %>
-  <div class="field">
-    <%= f.label :interviewer_id %><br />
-    <%= f.collection_select(:interviewer_id, User.interviewer, :id, :name) %>
-  </div>
-
-  <div class="field">
-    <%= f.label :schedule %><br />
-    <%= f.datetime_select :schedule, minute_step: 15, value: Time.now %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "予約" %>
-  </div>
-<% end %>
+<%= render 'form' %>

--- a/spec/models/interview_spec.rb
+++ b/spec/models/interview_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Interview, type: :model do
   let(:member) { FactoryBot.create(:user, :member) }
   let(:interviewer) { FactoryBot.create(:user, :interviewer) }
 
+  before { travel_to('2020-04-01 00:00') }
+
   it 'is valid with interviewer_id, schedule and schedule_status' do
     interview = member.interviews.build(interviewer_id: interviewer.id, schedule: Time.now.tomorrow)
     expect(interview.valid?).to be_truthy

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe InterviewsController, type: :request do
       it { is_expected.to have_http_status '302' }
 
       it 'deletes an interview' do
-        expect { subject }.to change(user.interviews, :count).by(0)
+        expect { subject }.to change(user.interviews, :count).by(-1)
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe InterviewsController, type: :request do
       it { is_expected.to have_http_status '302' }
 
       it 'does not delete an interview' do
-        expect { subject }.to change(user.interviews, :count).by(1)
+        expect { subject }.to change(user.interviews, :count).by(0)
       end
     end
   end

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -3,14 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe InterviewsController, type: :request do
-  let(:user) { FactoryBot.create(:user) }
-  let(:interviewer) { FactoryBot.create(:user, :interviewer) }
-  let(:another_interviewer) { FactoryBot.create(:user, :interviewer) }
-  let(:interview) { user.interviews.create(params) }
-  let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
-  let(:another_params) { { interviewer_id: another_interviewer.id, schedule: Time.now.tomorrow } }
-
   describe 'GET #new' do
+    let(:user) { FactoryBot.create(:user) }
+
     subject { get new_user_interview_path(user), params: { user_id: user.id }; response }
 
     context 'as an authenticated user' do
@@ -24,6 +19,10 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'POST #create' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
+    let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+
     subject { post user_interviews_path(user), params: { interview: params }; response }
 
     context 'as an authenticated user' do
@@ -45,6 +44,8 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'GET #index' do
+    let(:user) { FactoryBot.create(:user) }
+
     subject { get user_interviews_path(user); response }
 
     context 'as an authenticated user' do
@@ -58,6 +59,11 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'GET #edit' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:interview) { user.interviews.create(params) }
+    let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
+    let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+
     subject { get edit_user_interview_path(user, interview); response }
 
     context 'as an authenticated user' do
@@ -71,7 +77,14 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'PATCH #update' do
-    subject { patch user_interview_path(user, interview), params: { interview: another_params }; response }
+    let(:user) { FactoryBot.create(:user) }
+    let(:interview) { user.interviews.create(params) }
+    let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
+    let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+    let(:another_interviewer) { FactoryBot.create(:user, :interviewer) }
+    let(:edited_params) { { interviewer_id: another_interviewer.id, schedule: Time.now.tomorrow } }
+
+    subject { patch user_interview_path(user, interview), params: { interview: edited_params }; response }
 
     context 'as an authenticated user' do
       before { sign_in user }
@@ -92,6 +105,11 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'DELETE #destroy' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:interview) { user.interviews.create(params) }
+    let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
+    let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+
     subject { delete user_interview_path(user, interview); response }
 
     context 'as an authenticated user' do

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe InterviewsController, type: :request do
   let(:user) { FactoryBot.create(:user) }
   let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+  let(:another_interviewer) { FactoryBot.create(:user, :interviewer) }
   let(:interview) { user.interviews.create(params) }
   let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
+  let(:another_params) { { interviewer_id: another_interviewer.id, schedule: Time.now.tomorrow } }
 
   describe 'GET #new' do
     subject { get new_user_interview_path(user), params: { user_id: user.id }; response }
@@ -69,15 +71,23 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'PATCH #update' do
-    subject { patch user_interview_path(user, interview), params: { interview: params }; response }
+    subject { patch user_interview_path(user, interview), params: { interview: another_params }; response }
 
     context 'as an authenticated user' do
       before { sign_in user }
       it { is_expected.to have_http_status '302' }
+
+      it 'updates an interview' do
+        expect { subject }.to change { interview.reload.interviewer.id }.from(interviewer.id).to(another_interviewer.id)
+      end
     end
 
     context 'as an unauthorized' do
       it { is_expected.to have_http_status '302' }
+
+      it 'does not update an interview' do
+        expect { subject }.not_to(change { interview.reload.interviewer.id })
+      end
     end
   end
 

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe InterviewsController, type: :request do
   let(:user) { FactoryBot.create(:user) }
   let(:interviewer) { FactoryBot.create(:user, :interviewer) }
   let(:interview) { user.interviews.create(params) }
-  let(:params) { { interviewer: interviewer, schedule: Time.now.tomorrow, schedule_status: 'pending' } }
+  let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
 
   describe 'GET #new' do
     subject { get new_user_interview_path(user), params: { user_id: user.id }; response }
@@ -18,6 +18,27 @@ RSpec.describe InterviewsController, type: :request do
 
     context 'as an unauthorized' do
       it { is_expected.to have_http_status '302' }
+    end
+  end
+
+  describe 'POST #create' do
+    subject { post user_interviews_path(user), params: { interview: params }; response }
+
+    context 'as an authenticated user' do
+      before { sign_in user }
+      it { is_expected.to have_http_status '302' }
+
+      it 'creates an interview' do
+        expect { subject }.to change(user.interviews, :count).by(1)
+      end
+    end
+
+    context 'as an unauthorized' do
+      it { is_expected.to have_http_status '302' }
+
+      it 'dose not create an interview' do
+        expect { subject }.to change(user.interviews, :count).by(0)
+      end
     end
   end
 

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -68,6 +68,19 @@ RSpec.describe InterviewsController, type: :request do
     end
   end
 
+  describe 'PATCH #update' do
+    subject { patch user_interview_path(user, interview), params: { interview: params }; response }
+
+    context 'as an authenticated user' do
+      before { sign_in user }
+      it { is_expected.to have_http_status '302' }
+    end
+
+    context 'as an unauthorized' do
+      it { is_expected.to have_http_status '302' }
+    end
+  end
+
   describe 'DELETE #destroy' do
     subject { delete user_interview_path(user, interview); response }
 

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -59,10 +59,8 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'GET #edit' do
-    let(:user) { FactoryBot.create(:user) }
-    let(:interview) { user.interviews.create(params) }
-    let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
-    let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+    let(:user) { interview.user }
+    let(:interview) { FactoryBot.create(:interview) }
 
     subject { get edit_user_interview_path(user, interview); response }
 
@@ -77,10 +75,9 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'PATCH #update' do
-    let(:user) { FactoryBot.create(:user) }
-    let(:interview) { user.interviews.create(params) }
-    let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
-    let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+    let(:user) { interview.user }
+    let(:interview) { FactoryBot.create(:interview) }
+    let(:interviewer) { interview.interviewer }
     let(:another_interviewer) { FactoryBot.create(:user, :interviewer) }
     let(:edited_params) { { interviewer_id: another_interviewer.id, schedule: Time.now.tomorrow } }
 
@@ -105,10 +102,8 @@ RSpec.describe InterviewsController, type: :request do
   end
 
   describe 'DELETE #destroy' do
-    let(:user) { FactoryBot.create(:user) }
-    let(:interview) { user.interviews.create(params) }
-    let(:params) { { interviewer_id: interviewer.id, schedule: Time.now.tomorrow } }
-    let(:interviewer) { FactoryBot.create(:user, :interviewer) }
+    let(:user) { interview.user }
+    let(:interview) { FactoryBot.create(:interview) }
 
     subject { delete user_interview_path(user, interview); response }
 

--- a/spec/requests/interviews_spec.rb
+++ b/spec/requests/interviews_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe InterviewsController, type: :request do
     end
   end
 
+  describe 'GET #edit' do
+    subject { get edit_user_interview_path(user, interview); response }
+
+    context 'as an authenticated user' do
+      before { sign_in user }
+      it { is_expected.to have_http_status '200' }
+    end
+
+    context 'as an unauthorized' do
+      it { is_expected.to have_http_status '302' }
+    end
+  end
+
   describe 'DELETE #destroy' do
     subject { delete user_interview_path(user, interview); response }
 


### PR DESCRIPTION
## やりたいこと
- ユーザが面接内容を編集できるようにする

## やったこと
- interview の編集機能の実装
- リクエストスペックの追加
  - POST #create
  - POST #update
- interview new と edit の view をパーシャルで共通化

## 動作確認方法
### ローカル
- `$ bin/rails db:migrate` でデータベースを更新する
- `$ bin/rails s` でサーバを立てる
- http://localhost:3000/ にアクセス

### Web
ビルド中

### 確認してほしいこと
- 適当なユーザでログイン（下記は登録済みテスト用ユーザ）
  - email: shiraishi@test.jp
  - password: password
- 面接一覧ページの編集リンクから面接予約の更新ができるかどうか
- request spec がいい感じにかけているかどうか（特に let(:params) の使い方）